### PR TITLE
One-line update for iOS8

### DIFF
--- a/SBFlatDatePicker/SBFlatDatePicker.m
+++ b/SBFlatDatePicker/SBFlatDatePicker.m
@@ -235,7 +235,7 @@ const float LBL_BORDER_OFFSET = 8.0;
 //custom intialize based on desired forward/backward days
 -(void)initializeCalendarDays{
     
-    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     NSDate* current_Date = [NSDate date];
     NSMutableArray* calendarDates = [[NSMutableArray alloc] init];
     NSMutableArray* calendarTexts = [[NSMutableArray alloc] init];


### PR DESCRIPTION
'NSGregorianCalendar' (deprecated in iOS 8) → 'NSCalendarIdentifierGregorian'
Awesome datePicker, thank you for making it.